### PR TITLE
feat(export): add per-contact vCard export with 3.0/4.0 version choice

### DIFF
--- a/backend/carddav/vcard_mapper.go
+++ b/backend/carddav/vcard_mapper.go
@@ -30,12 +30,26 @@ type VCardExtra struct {
 	Properties map[string][]vcard.Field `json:"properties,omitempty"`
 }
 
-// ContactToVCard converts a Contact to a vCard 3.0 card.
+// ContactToVCard converts a Contact to a vCard 3.0 card. vCard 3.0 is used
+// everywhere internally (CardDAV sync, hashing) since it's what iOS/macOS
+// Contacts requires; user-triggered file exports can request 4.0 instead via
+// ContactToVCardVersion.
 func ContactToVCard(contact *models.Contact, photoDir string) vcard.Card {
+	return ContactToVCardVersion(contact, photoDir, "3.0")
+}
+
+// ContactToVCardVersion converts a Contact to a vCard, encoded for the given
+// VERSION ("3.0" or "4.0"). The two versions differ only in the VERSION
+// property and how the photo is embedded - vCard 3.0 requires ENCODING=b/TYPE
+// params (what iOS/macOS Contacts expects), while vCard 4.0 embeds the photo
+// as a data: URI per RFC 6350.
+func ContactToVCardVersion(contact *models.Contact, photoDir string, version string) vcard.Card {
 	card := make(vcard.Card)
 
-	// Required: VERSION - use 3.0 for iOS compatibility
-	card.SetValue(vcard.FieldVersion, "3.0")
+	if version != "4.0" {
+		version = "3.0"
+	}
+	card.SetValue(vcard.FieldVersion, version)
 
 	// UID - use VCardUID if set, otherwise generate a new one
 	uid := contact.VCardUID
@@ -93,8 +107,13 @@ func ContactToVCard(contact *models.Contact, photoDir string) vcard.Card {
 		if e.Value == "" {
 			continue
 		}
-		// EMAIL always carries INTERNET (vCard 3.0) regardless of label.
-		addTypedField(card, vcard.FieldEmail, &vcard.Field{Value: e.Value}, e.Type, nextGroup, "INTERNET")
+		// INTERNET distinguished EMAIL from X.400 addresses in vCard 3.0; vCard 4.0
+		// dropped it as a registered EMAIL TYPE value, so only emit it pre-4.0.
+		var baseTokens []string
+		if version != "4.0" {
+			baseTokens = []string{"INTERNET"}
+		}
+		addTypedField(card, vcard.FieldEmail, &vcard.Field{Value: e.Value}, e.Type, nextGroup, version, baseTokens...)
 	}
 
 	// TEL (phone) - emit every entry; fall back to the legacy scalar if the array is empty
@@ -106,7 +125,7 @@ func ContactToVCard(contact *models.Contact, photoDir string) vcard.Card {
 		if p.Value == "" {
 			continue
 		}
-		addTypedField(card, vcard.FieldTelephone, &vcard.Field{Value: p.Value}, p.Type, nextGroup)
+		addTypedField(card, vcard.FieldTelephone, &vcard.Field{Value: p.Value}, p.Type, nextGroup, version)
 	}
 
 	// ADR (address) - structured: POBox;Extended;Street;Locality;Region;Postal;Country
@@ -123,7 +142,7 @@ func ContactToVCard(contact *models.Contact, photoDir string) vcard.Card {
 		for i := range comps {
 			comps[i] = escapeComponent(comps[i])
 		}
-		addTypedField(card, vcard.FieldAddress, &vcard.Field{Value: strings.Join(comps, ";")}, a.Type, nextGroup)
+		addTypedField(card, vcard.FieldAddress, &vcard.Field{Value: strings.Join(comps, ";")}, a.Type, nextGroup, version)
 	}
 
 	// URL (websites)
@@ -131,7 +150,7 @@ func ContactToVCard(contact *models.Contact, photoDir string) vcard.Card {
 		if u.Value == "" {
 			continue
 		}
-		addTypedField(card, vcard.FieldURL, &vcard.Field{Value: u.Value}, u.Type, nextGroup)
+		addTypedField(card, vcard.FieldURL, &vcard.Field{Value: u.Value}, u.Type, nextGroup, version)
 	}
 
 	// IMPP (instant messaging / social handles) - service goes in the X-SERVICE-TYPE param
@@ -184,23 +203,27 @@ func ContactToVCard(contact *models.Contact, photoDir string) vcard.Card {
 	}
 
 	// PHOTO - read from disk, fall back to thumbnail
-	// Include both vCard 3.0 and 4.0 parameters for maximum compatibility:
-	// - ENCODING=b and TYPE=JPEG for vCard 3.0 (required by iOS)
-	// - MEDIATYPE=image/jpeg for vCard 4.0
 	photoData, mediaType := readContactPhoto(contact, photoDir)
 	if photoData != "" {
-		// Extract just the image type (e.g., "JPEG" from "image/jpeg")
-		imageType := "JPEG"
-		if strings.Contains(mediaType, "png") {
-			imageType = "PNG"
+		if version == "4.0" {
+			// vCard 4.0 (RFC 6350): PHOTO is a URI; embed inline as a data: URI.
+			card.Set(vcard.FieldPhoto, &vcard.Field{
+				Value: fmt.Sprintf("data:%s;base64,%s", mediaType, photoData),
+			})
+		} else {
+			// vCard 3.0: ENCODING=b and TYPE=JPEG/PNG, required by iOS.
+			imageType := "JPEG"
+			if strings.Contains(mediaType, "png") {
+				imageType = "PNG"
+			}
+			card.Set(vcard.FieldPhoto, &vcard.Field{
+				Value: photoData,
+				Params: vcard.Params{
+					"ENCODING": {"b"},
+					"TYPE":     {imageType},
+				},
+			})
 		}
-		card.Set(vcard.FieldPhoto, &vcard.Field{
-			Value: photoData,
-			Params: vcard.Params{
-				"ENCODING": {"b"},       // vCard 3.0: base64 encoding
-				"TYPE":     {imageType}, // vCard 3.0: image type
-			},
-		})
 	}
 
 	// Restore unmapped properties from VCardExtra. Skip any property that is now
@@ -718,12 +741,12 @@ func isCustomType(t string) bool {
 // emitted as a grouped X-ABLabel (Apple convention) so it survives round-trips
 // and renders as a named label. baseTypeTokens are TYPE values
 // always present regardless of the label (e.g. INTERNET for EMAIL).
-func addTypedField(card vcard.Card, fieldName string, field *vcard.Field, t string, nextGroup func() string, baseTypeTokens ...string) {
+func addTypedField(card vcard.Card, fieldName string, field *vcard.Field, t string, nextGroup func() string, version string, baseTypeTokens ...string) {
 	if isCustomType(t) {
 		group := nextGroup()
 		field.Group = group
 		if len(baseTypeTokens) > 0 {
-			field.Params = vcard.Params{vcard.ParamType: append([]string(nil), baseTypeTokens...)}
+			field.Params = vcard.Params{vcard.ParamType: caseTypeTokens(baseTypeTokens, version)}
 		}
 		card.Add(fieldName, field)
 		card.Add(fieldABLabel, &vcard.Field{Group: group, Value: strings.TrimSpace(t)})
@@ -731,9 +754,26 @@ func addTypedField(card vcard.Card, fieldName string, field *vcard.Field, t stri
 	}
 	tokens := append(append([]string(nil), baseTypeTokens...), typeTokens(t)...)
 	if len(tokens) > 0 {
-		field.Params = vcard.Params{vcard.ParamType: tokens}
+		field.Params = vcard.Params{vcard.ParamType: caseTypeTokens(tokens, version)}
 	}
 	card.Add(fieldName, field)
+}
+
+// caseTypeTokens matches TYPE parameter casing to convention: vCard 3.0
+// clients (notably iOS) write TYPE values upper case, while vCard 4.0
+// producers write them lower case. Both cases are valid per spec (TYPE is
+// case-insensitive), but matching convention keeps exported cards looking
+// native to their declared version.
+func caseTypeTokens(tokens []string, version string) []string {
+	out := make([]string, len(tokens))
+	for i, tok := range tokens {
+		if version == "4.0" {
+			out[i] = strings.ToLower(tok)
+		} else {
+			out[i] = strings.ToUpper(tok)
+		}
+	}
+	return out
 }
 
 // typeForField resolves the internal type token for an imported field, preferring

--- a/backend/controllers/export_controller.go
+++ b/backend/controllers/export_controller.go
@@ -3,12 +3,14 @@ package controllers
 import (
 	"bytes"
 	"encoding/csv"
+	"errors"
 	"fmt"
 	"meerkat/carddav"
 	apperrors "meerkat/errors"
 	"meerkat/logger"
 	"meerkat/models"
 	"net/http"
+	"regexp"
 	"strings"
 	"time"
 
@@ -347,6 +349,8 @@ func ExportContactsAsVCF(c *gin.Context, photoDir string) {
 		return
 	}
 
+	version := vcardVersionParam(c)
+
 	// Fetch all user contacts
 	var contacts []models.Contact
 	if err := db.Where("user_id = ?", userID).
@@ -362,7 +366,7 @@ func ExportContactsAsVCF(c *gin.Context, photoDir string) {
 	encoder := vcard.NewEncoder(&buf)
 
 	for _, contact := range contacts {
-		card := carddav.ContactToVCard(&contact, photoDir)
+		card := carddav.ContactToVCardVersion(&contact, photoDir, version)
 		if err := encoder.Encode(card); err != nil {
 			log.Error().Err(err).Uint("contact_id", contact.ID).Msg("Failed to encode contact as vCard")
 			// Continue with other contacts instead of failing completely
@@ -384,4 +388,70 @@ func ExportContactsAsVCF(c *gin.Context, photoDir string) {
 	log.Info().
 		Int("contacts", len(contacts)).
 		Msg("VCF export completed successfully")
+}
+
+// ExportContactAsVCF exports a single user contact as a VCF (vCard) file
+func ExportContactAsVCF(c *gin.Context, photoDir string) {
+	db := c.MustGet("db").(*gorm.DB)
+	log := logger.FromContext(c)
+
+	userID, ok := currentUserID(c)
+	if !ok {
+		return
+	}
+
+	contactID := c.Param("id")
+	version := vcardVersionParam(c)
+
+	var contact models.Contact
+	if err := db.Where("user_id = ?", userID).First(&contact, contactID).Error; err != nil {
+		if errors.Is(err, gorm.ErrRecordNotFound) {
+			apperrors.AbortWithError(c, apperrors.ErrNotFound("Contact").WithDetails("id", contactID))
+		} else {
+			apperrors.AbortWithError(c, apperrors.ErrDatabase("Failed to retrieve contact").WithError(err))
+		}
+		return
+	}
+
+	var buf bytes.Buffer
+	encoder := vcard.NewEncoder(&buf)
+	card := carddav.ContactToVCardVersion(&contact, photoDir, version)
+	if err := encoder.Encode(card); err != nil {
+		log.Error().Err(err).Uint("contact_id", contact.ID).Msg("Failed to encode contact as vCard")
+		apperrors.AbortWithError(c, apperrors.ErrInternal("Failed to generate vCard"))
+		return
+	}
+
+	filename := fmt.Sprintf("%s.vcf", contactFilenameSlug(contact.Firstname, contact.Lastname))
+
+	c.Header("Content-Description", "File Transfer")
+	c.Header("Content-Disposition", fmt.Sprintf("attachment; filename=%s", filename))
+	c.Header("Content-Type", "text/vcard; charset=utf-8")
+	c.Header("Content-Length", fmt.Sprintf("%d", buf.Len()))
+
+	c.Data(http.StatusOK, "text/vcard; charset=utf-8", buf.Bytes())
+
+	log.Info().Uint("contact_id", contact.ID).Msg("Single contact VCF export completed successfully")
+}
+
+// vcardVersionParam reads the ?version= query param and returns a valid
+// vCard VERSION ("3.0" or "4.0"), defaulting to "3.0" for anything else.
+func vcardVersionParam(c *gin.Context) string {
+	if c.Query("version") == "4.0" {
+		return "4.0"
+	}
+	return "3.0"
+}
+
+var filenameUnsafeChars = regexp.MustCompile(`[^a-z0-9]+`)
+
+// contactFilenameSlug builds a lowercase, hyphenated filename stem from a
+// contact's name, falling back to "contact" if nothing usable remains.
+func contactFilenameSlug(firstname, lastname string) string {
+	slug := filenameUnsafeChars.ReplaceAllString(strings.ToLower(strings.TrimSpace(firstname+"-"+lastname)), "-")
+	slug = strings.Trim(slug, "-")
+	if slug == "" {
+		return "contact"
+	}
+	return slug
 }

--- a/backend/main.go
+++ b/backend/main.go
@@ -102,7 +102,7 @@ func main() {
 	corsConfig := cors.Config{
 		AllowMethods:     []string{"GET", "POST", "PUT", "PATCH", "DELETE", "OPTIONS", "PROPFIND", "REPORT", "MKCOL", "COPY", "MOVE"},
 		AllowHeaders:     []string{"Origin", "Content-Type", "Authorization", "Depth", "If-Match", "If-None-Match"},
-		ExposeHeaders:    []string{"Content-Length", "ETag"},
+		ExposeHeaders:    []string{"Content-Length", "ETag", "Content-Disposition"},
 		AllowCredentials: true,
 		MaxAge:           12 * time.Hour, // Cache preflight for 12 hours
 	}

--- a/backend/routes/routes.go
+++ b/backend/routes/routes.go
@@ -146,6 +146,9 @@ func RegisterRoutes(router *gin.Engine, cfg *config.Config, db *gorm.DB, oidcPro
 			protected.GET("/export/vcf", func(c *gin.Context) {
 				controllers.ExportContactsAsVCF(c, cfg.ProfilePhotoDir)
 			})
+			protected.GET("/contacts/:id/vcf", func(c *gin.Context) {
+				controllers.ExportContactAsVCF(c, cfg.ProfilePhotoDir)
+			})
 
 			// Graph/Network visualization route
 			protected.GET("/graph", controllers.GetGraph)

--- a/frontend/src/ContactDetailPage.tsx
+++ b/frontend/src/ContactDetailPage.tsx
@@ -12,6 +12,7 @@ import {
   archiveContact,
   unarchiveContact
 } from './api/contacts';
+import { exportContactAsVcf } from './api/export';
 import { getCurrentUser } from './api/admin';
 import { resolveEnabledFields, ContactFieldKey } from './contactFields';
 import { 
@@ -554,6 +555,21 @@ export default function ContactDetailPage() {
     }
   };
 
+  const handleExportVcard = async (version: '3.0' | '4.0') => {
+    if (!id) return;
+
+    try {
+      await exportContactAsVcf(id, version);
+    } catch (err) {
+      console.error('Error exporting contact as vCard:', err);
+      if (err instanceof ApiError) {
+        showError(err.getDisplayMessage());
+      } else {
+        showError(t('contactDetail.exportVcardError'));
+      }
+    }
+  };
+
   const handleUnarchiveContact = async () => {
     if (!contact || !id) return;
 
@@ -650,6 +666,7 @@ export default function ContactDetailPage() {
         onStayInTouch={contact.archived ? undefined : handleStayInTouch}
         onArchiveContact={contact.archived ? undefined : handleArchiveContact}
         onUnarchiveContact={contact.archived ? handleUnarchiveContact : undefined}
+        onExportVcard={handleExportVcard}
       />
 
       {/* General Information and Timeline - Two Column Layout */}

--- a/frontend/src/DataSettingsPage.tsx
+++ b/frontend/src/DataSettingsPage.tsx
@@ -10,10 +10,14 @@ import {
   Stack,
   Alert,
   CircularProgress,
+  FormControl,
+  InputLabel,
+  Select,
+  MenuItem,
 } from '@mui/material';
 import DownloadIcon from '@mui/icons-material/Download';
 import CloudDownloadIcon from '@mui/icons-material/CloudDownload';
-import { exportDataAsCsv, exportContactsAsVcf } from './api/export';
+import { exportDataAsCsv, exportContactsAsVcf, VCardVersion } from './api/export';
 import CustomFieldsSettings from './components/CustomFieldsSettings';
 import ContactFieldSettings from './components/ContactFieldSettings';
 import CalendarSyncSettings from './components/CalendarSyncSettings';
@@ -29,6 +33,7 @@ export default function DataSettingsPage() {
   const [exportingVcf, setExportingVcf] = useState(false);
   const [exportVcfError, setExportVcfError] = useState('');
   const [exportVcfSuccess, setExportVcfSuccess] = useState('');
+  const [vcfVersion, setVcfVersion] = useState<VCardVersion>('3.0');
 
   const handleExportData = async () => {
     setExportError('');
@@ -52,7 +57,7 @@ export default function DataSettingsPage() {
     setExportingVcf(true);
 
     try {
-      await exportContactsAsVcf();
+      await exportContactsAsVcf(vcfVersion);
       setExportVcfSuccess(t('settings.exportVcf.success'));
     } catch (error) {
       const errorMessage = error instanceof Error ? error.message : t('settings.exportVcf.error');
@@ -153,15 +158,29 @@ export default function DataSettingsPage() {
             </Typography>
             {exportVcfError && <Alert severity="error" sx={{ py: 0 }}>{exportVcfError}</Alert>}
             {exportVcfSuccess && <Alert severity="success" sx={{ py: 0 }}>{exportVcfSuccess}</Alert>}
-            <Button
-              variant="contained"
-              size="small"
-              startIcon={exportingVcf ? <CircularProgress size={16} color="inherit" /> : <DownloadIcon />}
-              onClick={handleExportVcf}
-              disabled={exportingVcf}
-            >
-              {exportingVcf ? t('settings.exportVcf.exporting') : t('settings.exportVcf.downloadButton')}
-            </Button>
+            <Stack direction="row" spacing={1.5} alignItems="center">
+              <FormControl size="small" sx={{ minWidth: 220 }}>
+                <InputLabel id="vcf-version-label">{t('settings.exportVcf.versionLabel')}</InputLabel>
+                <Select
+                  labelId="vcf-version-label"
+                  label={t('settings.exportVcf.versionLabel')}
+                  value={vcfVersion}
+                  onChange={(e) => setVcfVersion(e.target.value as VCardVersion)}
+                >
+                  <MenuItem value="3.0">{t('contactDetail.exportVcard3')}</MenuItem>
+                  <MenuItem value="4.0">{t('contactDetail.exportVcard4')}</MenuItem>
+                </Select>
+              </FormControl>
+              <Button
+                variant="contained"
+                size="small"
+                startIcon={exportingVcf ? <CircularProgress size={16} color="inherit" /> : <DownloadIcon />}
+                onClick={handleExportVcf}
+                disabled={exportingVcf}
+              >
+                {exportingVcf ? t('settings.exportVcf.exporting') : t('settings.exportVcf.downloadButton')}
+              </Button>
+            </Stack>
           </Stack>
         </CardContent>
       </Card>

--- a/frontend/src/api/export.ts
+++ b/frontend/src/api/export.ts
@@ -1,6 +1,8 @@
 // Export API functions
 import { API_BASE_URL, apiFetch, getAuthHeaders, parseErrorResponse } from './client';
 
+export type VCardVersion = '3.0' | '4.0';
+
 /**
  * Helper function to download a file from an API response
  */
@@ -51,8 +53,8 @@ export async function exportDataAsCsv(): Promise<void> {
  * Export all contacts as VCF (vCard)
  * Downloads a VCF file containing all contacts with their photos
  */
-export async function exportContactsAsVcf(): Promise<void> {
-  const response = await apiFetch(`${API_BASE_URL}/export/vcf`, {
+export async function exportContactsAsVcf(version: VCardVersion = '3.0'): Promise<void> {
+  const response = await apiFetch(`${API_BASE_URL}/export/vcf?version=${version}`, {
     method: 'GET',
     headers: getAuthHeaders(),
   });
@@ -63,4 +65,22 @@ export async function exportContactsAsVcf(): Promise<void> {
   }
 
   await downloadFileFromResponse(response, 'meerkat-contacts.vcf');
+}
+
+/**
+ * Export a single contact as VCF (vCard)
+ * Downloads a VCF file for the given contact
+ */
+export async function exportContactAsVcf(contactId: number | string, version: VCardVersion = '3.0'): Promise<void> {
+  const response = await apiFetch(`${API_BASE_URL}/contacts/${contactId}/vcf?version=${version}`, {
+    method: 'GET',
+    headers: getAuthHeaders(),
+  });
+
+  if (!response.ok) {
+    const error = await parseErrorResponse(response);
+    throw error;
+  }
+
+  await downloadFileFromResponse(response, `contact-${contactId}.vcf`);
 }

--- a/frontend/src/components/ContactHeader.tsx
+++ b/frontend/src/components/ContactHeader.tsx
@@ -1,4 +1,5 @@
-import { Box, Card, CardContent, Avatar, Typography, Chip, IconButton, Stack, TextField, Autocomplete, Button } from '@mui/material';
+import { useState } from 'react';
+import { Box, Card, CardContent, Avatar, Typography, Chip, IconButton, Stack, TextField, Autocomplete, Button, Tooltip, Menu, MenuItem } from '@mui/material';
 import EditIcon from '@mui/icons-material/Edit';
 import SaveIcon from '@mui/icons-material/Save';
 import CloseIcon from '@mui/icons-material/Close';
@@ -8,6 +9,7 @@ import CameraAltIcon from '@mui/icons-material/CameraAlt';
 import AutoModeIcon from '@mui/icons-material/AutoMode';
 import ArchiveIcon from '@mui/icons-material/Archive';
 import UnarchiveIcon from '@mui/icons-material/Unarchive';
+import ContactMailIcon from '@mui/icons-material/ContactMail';
 import { useTranslation } from 'react-i18next';
 import { ContactFieldKey, resolveEnabledFields } from '../contactFields';
 
@@ -54,6 +56,7 @@ interface ContactHeaderProps {
   onStayInTouch?: () => void;
   onArchiveContact?: () => void;
   onUnarchiveContact?: () => void;
+  onExportVcard?: (version: '3.0' | '4.0') => void;
 }
 
 export default function ContactHeader({
@@ -77,11 +80,18 @@ export default function ContactHeader({
   onUploadProfilePicture,
   onStayInTouch,
   onArchiveContact,
-  onUnarchiveContact
+  onUnarchiveContact,
+  onExportVcard
 }: ContactHeaderProps) {
   const { t } = useTranslation();
   const enabled = enabledFields ?? resolveEnabledFields(null);
   const isOn = (key: ContactFieldKey) => enabled.has(key);
+
+  const [exportMenuAnchor, setExportMenuAnchor] = useState<null | HTMLElement>(null);
+  const handleExportVersion = (version: '3.0' | '4.0') => {
+    setExportMenuAnchor(null);
+    onExportVcard?.(version);
+  };
 
   const displayName = [
     contact.prefix,
@@ -261,7 +271,31 @@ export default function ContactHeader({
                       <EditIcon fontSize="small" />
                     </IconButton>
                   </Box>
-                  <Box sx={{ display: 'flex', gap: 1 }}>
+                  <Box sx={{ display: 'flex', gap: 1, alignItems: 'center' }}>
+                    {onExportVcard && (
+                      <>
+                        <Tooltip title={t('contactDetail.exportVcard')}>
+                          <IconButton
+                            size="small"
+                            onClick={(e) => setExportMenuAnchor(e.currentTarget)}
+                          >
+                            <ContactMailIcon fontSize="small" />
+                          </IconButton>
+                        </Tooltip>
+                        <Menu
+                          anchorEl={exportMenuAnchor}
+                          open={Boolean(exportMenuAnchor)}
+                          onClose={() => setExportMenuAnchor(null)}
+                        >
+                          <MenuItem onClick={() => handleExportVersion('3.0')}>
+                            {t('contactDetail.exportVcard3')}
+                          </MenuItem>
+                          <MenuItem onClick={() => handleExportVersion('4.0')}>
+                            {t('contactDetail.exportVcard4')}
+                          </MenuItem>
+                        </Menu>
+                      </>
+                    )}
                     {contact.archived ? (
                       onUnarchiveContact && (
                         <Button

--- a/frontend/src/i18n/locales/de.json
+++ b/frontend/src/i18n/locales/de.json
@@ -289,7 +289,11 @@
     "archive": "Archivieren",
     "unarchive": "Wiederherstellen",
     "archivedBadge": "Archiviert",
-    "archiveConfirmation": "Möchten Sie diesen Kontakt wirklich archivieren? Alle Erinnerungen werden gelöscht. Sie können den Kontakt später wiederherstellen, aber die Erinnerungen werden nicht wiederhergestellt."
+    "archiveConfirmation": "Möchten Sie diesen Kontakt wirklich archivieren? Alle Erinnerungen werden gelöscht. Sie können den Kontakt später wiederherstellen, aber die Erinnerungen werden nicht wiederhergestellt.",
+    "exportVcard": "vCard exportieren",
+    "exportVcard3": "vCard 3.0 (beste Kompatibilität)",
+    "exportVcard4": "vCard 4.0",
+    "exportVcardError": "Kontakt konnte nicht als vCard exportiert werden. Bitte versuchen Sie es erneut."
   },
   "noteDialog": {
     "title": "Notiz hinzufügen",
@@ -452,6 +456,7 @@
     "exportVcf": {
       "title": "Kontakte als VCF exportieren",
       "description": "Laden Sie alle Ihre Kontakte als VCF-Datei (vCard) herunter. Dieses Format ist mit den meisten Kontakt-Apps kompatibel und enthält Profilfotos.",
+      "versionLabel": "vCard-Version",
       "downloadButton": "VCF herunterladen",
       "exporting": "Exportiere...",
       "success": "Ihre Kontakte wurden erfolgreich exportiert.",

--- a/frontend/src/i18n/locales/en.json
+++ b/frontend/src/i18n/locales/en.json
@@ -289,7 +289,11 @@
     "archive": "Archive",
     "unarchive": "Unarchive",
     "archivedBadge": "Archived",
-    "archiveConfirmation": "Are you sure you want to archive this contact? All reminders will be deleted. You can unarchive later, but reminders won't be restored."
+    "archiveConfirmation": "Are you sure you want to archive this contact? All reminders will be deleted. You can unarchive later, but reminders won't be restored.",
+    "exportVcard": "Export vCard",
+    "exportVcard3": "vCard 3.0 (best compatibility)",
+    "exportVcard4": "vCard 4.0",
+    "exportVcardError": "Failed to export contact as vCard. Please try again."
   },
   "noteDialog": {
     "title": "Add Note",
@@ -452,6 +456,7 @@
     "exportVcf": {
       "title": "Export Contacts as VCF",
       "description": "Download all your contacts as a VCF (vCard) file. This format is compatible with most contact apps and includes profile photos.",
+      "versionLabel": "vCard version",
       "downloadButton": "Download VCF",
       "exporting": "Exporting...",
       "success": "Your contacts have been exported successfully.",

--- a/frontend/src/i18n/locales/es.json
+++ b/frontend/src/i18n/locales/es.json
@@ -289,7 +289,11 @@
     "archive": "Archivar",
     "unarchive": "Desarchivar",
     "archivedBadge": "Archivado",
-    "archiveConfirmation": "¿Estás seguro de que quieres archivar este contacto? Todos los recordatorios serán eliminados. Puedes desarchivarlo más tarde, pero los recordatorios no se restaurarán."
+    "archiveConfirmation": "¿Estás seguro de que quieres archivar este contacto? Todos los recordatorios serán eliminados. Puedes desarchivarlo más tarde, pero los recordatorios no se restaurarán.",
+    "exportVcard": "Exportar vCard",
+    "exportVcard3": "vCard 3.0 (mejor compatibilidad)",
+    "exportVcard4": "vCard 4.0",
+    "exportVcardError": "No se pudo exportar el contacto como vCard. Inténtalo de nuevo."
   },
   "noteDialog": {
     "title": "Agregar Nota",
@@ -452,6 +456,7 @@
     "exportVcf": {
       "title": "Exportar Contactos como VCF",
       "description": "Descarga todos tus contactos como archivo VCF (vCard). Este formato es compatible con la mayoría de las aplicaciones de contactos e incluye fotos de perfil.",
+      "versionLabel": "Versión de vCard",
       "downloadButton": "Descargar VCF",
       "exporting": "Exportando...",
       "success": "Tus contactos han sido exportados exitosamente.",

--- a/frontend/src/i18n/locales/fr.json
+++ b/frontend/src/i18n/locales/fr.json
@@ -289,7 +289,11 @@
     "archive": "Archiver",
     "unarchive": "Désarchiver",
     "archivedBadge": "Archivé",
-    "archiveConfirmation": "Êtes-vous sûr de vouloir archiver ce contact ? Tous les rappels seront supprimés. Vous pourrez le désarchiver plus tard, mais les rappels ne seront pas restaurés."
+    "archiveConfirmation": "Êtes-vous sûr de vouloir archiver ce contact ? Tous les rappels seront supprimés. Vous pourrez le désarchiver plus tard, mais les rappels ne seront pas restaurés.",
+    "exportVcard": "Exporter en vCard",
+    "exportVcard3": "vCard 3.0 (compatibilité optimale)",
+    "exportVcard4": "vCard 4.0",
+    "exportVcardError": "Échec de l'exportation du contact en vCard. Veuillez réessayer."
   },
   "noteDialog": {
     "title": "Ajouter une note",
@@ -452,6 +456,7 @@
     "exportVcf": {
       "title": "Exporter les contacts en VCF",
       "description": "Téléchargez tous vos contacts au format VCF (vCard). Ce format est compatible avec la plupart des applications de contacts et inclut les photos de profil.",
+      "versionLabel": "Version vCard",
       "downloadButton": "Télécharger le VCF",
       "exporting": "Exportation en cours...",
       "success": "Vos contacts ont été exportés avec succès.",

--- a/frontend/src/i18n/locales/it.json
+++ b/frontend/src/i18n/locales/it.json
@@ -289,7 +289,11 @@
     "archive": "Archivia",
     "unarchive": "Ripristina",
     "archivedBadge": "Archiviato",
-    "archiveConfirmation": "Sei sicuro di voler archiviare questo contatto? Tutti i promemoria verranno eliminati. Potrai ripristinarlo in seguito, ma i promemoria non verranno recuperati."
+    "archiveConfirmation": "Sei sicuro di voler archiviare questo contatto? Tutti i promemoria verranno eliminati. Potrai ripristinarlo in seguito, ma i promemoria non verranno recuperati.",
+    "exportVcard": "Esporta vCard",
+    "exportVcard3": "vCard 3.0 (massima compatibilità)",
+    "exportVcard4": "vCard 4.0",
+    "exportVcardError": "Impossibile esportare il contatto come vCard. Riprova."
   },
   "noteDialog": {
     "title": "Aggiungi Nota",
@@ -452,6 +456,7 @@
     "exportVcf": {
       "title": "Esporta Contatti come VCF",
       "description": "Scarica tutti i tuoi contatti come file VCF (vCard). Questo formato è compatibile con la maggior parte delle app contatti e include le foto profilo.",
+      "versionLabel": "Versione vCard",
       "downloadButton": "Scarica VCF",
       "exporting": "Esportazione in corso...",
       "success": "I tuoi contatti sono stati esportati con successo.",


### PR DESCRIPTION
Add a single-contact VCF export endpoint (GET /contacts/:id/vcf) alongside the existing bulk export, with an icon-menu trigger on the contact detail header and a version dropdown on the bulk "Export Contacts as VCF" setting.

Both endpoints accept ?version=3.0|4.0: 4.0 embeds photos as a data: URI per RFC 6350 and drops the vCard 3.0 EMAIL TYPE=INTERNET convention, lowercasing TYPE tokens to match version convention.

Also expose Content-Disposition via CORS so the browser can read the server-provided filename instead of falling back to a generic one.