### PR TITLE
feat: allow toggling birthday reminders on existing contacts

### DIFF
--- a/frontend/src/ContactDetailPage.tsx
+++ b/frontend/src/ContactDetailPage.tsx
@@ -25,8 +25,12 @@ import {
 import {
   ReminderCompletion,
   getCompletionsForContact,
-  deleteCompletion
+  deleteCompletion,
+  createReminder,
+  updateReminder,
+  deleteReminder
 } from './api/reminders';
+import { computeNextBirthdayOccurrence, findBirthdayReminder, buildBirthdayReminderPayload } from './utils/birthdayReminder';
 import {
   Box,
   Card,
@@ -374,6 +378,7 @@ export default function ContactDetailPage() {
     }
 
     try {
+      const previousBirthday = field === 'birthday' ? contact.birthday : undefined;
       const updatedContact = await updateContact(id!, {
         ...contact,
         [field]: valueToSave
@@ -382,12 +387,56 @@ export default function ContactDetailPage() {
       setEditingField(null);
       setEditValue('');
       setValidationError('');
+
+      if (field === 'birthday' && previousBirthday) {
+        const existingReminder = findBirthdayReminder(reminders, previousBirthday);
+        if (existingReminder) {
+          if (!valueToSave) {
+            await deleteReminder(existingReminder.ID);
+            await refreshReminders();
+          } else {
+            const nextOccurrence = computeNextBirthdayOccurrence(valueToSave);
+            if (nextOccurrence) {
+              await updateReminder(existingReminder.ID, { remind_at: nextOccurrence.toISOString() });
+              await refreshReminders();
+            }
+          }
+        }
+      }
     } catch (err) {
       console.error('Error updating contact:', err);
       if (err instanceof ApiError) {
         const errorMessage = err.getDisplayMessage();
         setValidationError(errorMessage);
         showError(errorMessage);
+      } else {
+        showError(t('contactDetail.updateError'));
+      }
+    }
+  };
+
+  const handleToggleBirthdayReminder = async () => {
+    if (!contact || !contact.birthday) return;
+
+    const existingReminder = findBirthdayReminder(reminders, contact.birthday);
+    try {
+      if (existingReminder) {
+        await deleteReminder(existingReminder.ID);
+      } else {
+        const payload = buildBirthdayReminderPayload(
+          contact.ID,
+          contact.birthday,
+          t('reminders.birthdayMessage', { name: `${contact.firstname} ${contact.lastname}` })
+        );
+        if (payload) {
+          await createReminder(contact.ID, payload);
+        }
+      }
+      await refreshReminders();
+    } catch (err) {
+      console.error('Error toggling birthday reminder:', err);
+      if (err instanceof ApiError) {
+        showError(err.getDisplayMessage());
       } else {
         showError(t('contactDetail.updateError'));
       }
@@ -683,6 +732,8 @@ export default function ContactDetailPage() {
           onEditRelationship={handleEditRelationship}
           onDeleteRelationship={handleDeleteRelationship}
           customFieldNames={customFieldNames}
+          reminders={reminders}
+          onToggleBirthdayReminder={handleToggleBirthdayReminder}
         />
 
         {/* Timeline and Reminders Tabs */}

--- a/frontend/src/components/AddContactDialog.tsx
+++ b/frontend/src/components/AddContactDialog.tsx
@@ -22,6 +22,7 @@ import { createReminder } from '../api/reminders';
 import { useSnackbar } from '../context/SnackbarContext';
 import { handleError, getErrorMessage } from '../utils/errorHandler';
 import { useDateFormat } from '../DateFormatProvider';
+import { buildBirthdayReminderPayload } from '../utils/birthdayReminder';
 import { ContactFieldKey, resolveEnabledFields } from '../contactFields';
 
 interface AddContactDialogProps {
@@ -186,38 +187,13 @@ export default function AddContactDialog({
       const newContact = await createContact(contactData);
 
       if (createBirthdayReminder && birthdayISO) {
-        let day: number | undefined;
-        let month: number | undefined;
-
-        if (birthdayISO.startsWith('--')) {
-          month = parseInt(birthdayISO.substring(2, 4), 10) - 1;
-          day = parseInt(birthdayISO.substring(5, 7), 10);
-        } else {
-          const parts = birthdayISO.split('-');
-          if (parts.length === 3) {
-            month = parseInt(parts[1], 10) - 1;
-            day = parseInt(parts[2], 10);
-          }
-        }
-
-        if (day !== undefined && month !== undefined && !isNaN(day) && !isNaN(month)) {
-          const today = new Date();
-          let nextBirthday = new Date(today.getFullYear(), month, day);
-
-          if (nextBirthday < today) {
-            nextBirthday.setFullYear(today.getFullYear() + 1);
-          }
-
-          nextBirthday.setHours(9, 0, 0, 0);
-
-          await createReminder(newContact.ID, {
-            message: t('reminders.birthdayMessage', { name: `${newContact.firstname} ${newContact.lastname}` }),
-            by_mail: true,
-            remind_at: nextBirthday.toISOString(),
-            recurrence: 'yearly',
-            reoccur_from_completion: false,
-            contact_id: newContact.ID
-          });
+        const payload = buildBirthdayReminderPayload(
+          newContact.ID,
+          birthdayISO,
+          t('reminders.birthdayMessage', { name: `${newContact.firstname} ${newContact.lastname}` })
+        );
+        if (payload) {
+          await createReminder(newContact.ID, payload);
         }
       }
 

--- a/frontend/src/components/ContactInformation.tsx
+++ b/frontend/src/components/ContactInformation.tsx
@@ -1,5 +1,5 @@
 import { useState, useMemo } from 'react';
-import { Card, CardContent, Divider, Stack, Box, Tabs, Tab, Button, Typography } from '@mui/material';
+import { Card, CardContent, Divider, Stack, Box, Tabs, Tab, Button, Typography, FormControlLabel, Switch } from '@mui/material';
 import EmailIcon from '@mui/icons-material/Email';
 import PhoneIcon from '@mui/icons-material/Phone';
 import CakeIcon from '@mui/icons-material/Cake';
@@ -23,8 +23,10 @@ import AddressFields from './AddressFields';
 import RelationshipList from './RelationshipList';
 import { Relationship, IncomingRelationship } from '../api/relationships';
 import { Contact, ContactValue, ContactAddress } from '../api/contacts';
+import { Reminder } from '../api/reminders';
 import { ContactFieldKey, resolveEnabledFields } from '../contactFields';
 import { useDateFormat } from '../DateFormatProvider';
+import { findBirthdayReminder } from '../utils/birthdayReminder';
 
 interface ContactInformationProps {
   contact: Partial<Contact>;
@@ -45,6 +47,9 @@ interface ContactInformationProps {
   onDeleteRelationship?: (relationshipId: number) => void;
   // Custom fields
   customFieldNames?: string[];
+  // Birthday reminder
+  reminders?: Reminder[];
+  onToggleBirthdayReminder?: () => void;
 }
 
 const iconSx = { mr: 1, color: 'text.secondary', fontSize: '1.2rem' };
@@ -67,12 +72,19 @@ export default function ContactInformation({
   onEditRelationship,
   onDeleteRelationship,
   customFieldNames = [],
+  reminders = [],
+  onToggleBirthdayReminder,
 }: ContactInformationProps) {
   const { t } = useTranslation();
   const { formatBirthday, getBirthdayPlaceholder, calculateAge } = useDateFormat();
   const [activeTab, setActiveTab] = useState(0);
   const enabled = enabledFields ?? resolveEnabledFields(null);
   const isOn = (key: ContactFieldKey) => enabled.has(key);
+
+  const hasBirthdayReminder = useMemo(
+    () => !!(contact.birthday && findBirthdayReminder(reminders, contact.birthday)),
+    [reminders, contact.birthday]
+  );
 
   const birthdayAgeSuffix = useMemo(() => {
     if (!contact.birthday) return undefined;
@@ -204,22 +216,36 @@ export default function ContactInformation({
             )}
 
             {isOn('birthday') && (
-              <EditableField
-                icon={<CakeIcon sx={iconSx} />}
-                label={t('contactDetail.birthday')}
-                field="birthday"
-                value={contact.birthday || ''}
-                formattedDisplayValue={contact.birthday ? formatBirthday(contact.birthday) : undefined}
-                placeholder={getBirthdayPlaceholder()}
-                displaySuffix={birthdayAgeSuffix}
-                isEditing={editingField === 'birthday'}
-                editValue={editValue}
-                validationError={validationError}
-                onEditStart={onEditStart}
-                onEditCancel={onEditCancel}
-                onEditSave={onEditSave}
-                onEditValueChange={onEditValueChange}
-              />
+              <>
+                <EditableField
+                  icon={<CakeIcon sx={iconSx} />}
+                  label={t('contactDetail.birthday')}
+                  field="birthday"
+                  value={contact.birthday || ''}
+                  formattedDisplayValue={contact.birthday ? formatBirthday(contact.birthday) : undefined}
+                  placeholder={getBirthdayPlaceholder()}
+                  displaySuffix={birthdayAgeSuffix}
+                  isEditing={editingField === 'birthday'}
+                  editValue={editValue}
+                  validationError={validationError}
+                  onEditStart={onEditStart}
+                  onEditCancel={onEditCancel}
+                  onEditSave={onEditSave}
+                  onEditValueChange={onEditValueChange}
+                />
+                {contact.birthday && onToggleBirthdayReminder && (
+                  <FormControlLabel
+                    sx={{ ml: 4 }}
+                    control={
+                      <Switch
+                        checked={hasBirthdayReminder}
+                        onChange={onToggleBirthdayReminder}
+                      />
+                    }
+                    label={t('contactDetail.birthdayReminder')}
+                  />
+                )}
+              </>
             )}
 
             {isOn('anniversary') && (

--- a/frontend/src/i18n/locales/de.json
+++ b/frontend/src/i18n/locales/de.json
@@ -250,6 +250,7 @@
     "phone": "Telefon",
     "birthday": "Geburtstag",
     "birthdayError": "Ungültiges Datumsformat. Überprüfen Sie Ihre Datumsformat-Einstellung.",
+    "birthdayReminder": "Geburtstagserinnerung",
     "address": "Adresse",
     "workInfo": "Arbeitsinformationen",
     "foodPreferences": "Essensvorlieben",

--- a/frontend/src/i18n/locales/en.json
+++ b/frontend/src/i18n/locales/en.json
@@ -250,6 +250,7 @@
     "phone": "Phone",
     "birthday": "Birthday",
     "birthdayError": "Invalid date format. Check your date format setting.",
+    "birthdayReminder": "Birthday reminder",
     "address": "Address",
     "workInfo": "Work Information",
     "foodPreferences": "Food Preferences",

--- a/frontend/src/i18n/locales/es.json
+++ b/frontend/src/i18n/locales/es.json
@@ -250,6 +250,7 @@
     "phone": "Teléfono",
     "birthday": "Cumpleaños",
     "birthdayError": "Formato de fecha inválido. Verifica tu configuración de formato de fecha.",
+    "birthdayReminder": "Recordatorio de cumpleaños",
     "address": "Dirección",
     "workInfo": "Información Laboral",
     "foodPreferences": "Preferencias Alimentarias",

--- a/frontend/src/i18n/locales/fr.json
+++ b/frontend/src/i18n/locales/fr.json
@@ -250,6 +250,7 @@
     "phone": "Téléphone",
     "birthday": "Anniversaire",
     "birthdayError": "Format de date invalide. Vérifiez votre paramètre de format de date.",
+    "birthdayReminder": "Rappel d'anniversaire",
     "address": "Adresse",
     "workInfo": "Informations professionnelles",
     "foodPreferences": "Préférences alimentaires",

--- a/frontend/src/i18n/locales/it.json
+++ b/frontend/src/i18n/locales/it.json
@@ -250,6 +250,7 @@
     "phone": "Telefono",
     "birthday": "Compleanno",
     "birthdayError": "Formato data non valido. Controlla le impostazioni del formato data.",
+    "birthdayReminder": "Promemoria compleanno",
     "address": "Indirizzo",
     "workInfo": "Informazioni Lavorative",
     "foodPreferences": "Preferenze Alimentari",

--- a/frontend/src/utils/birthdayReminder.ts
+++ b/frontend/src/utils/birthdayReminder.ts
@@ -1,0 +1,78 @@
+import { Reminder, ReminderFormData } from '../api/reminders';
+
+// Extracts month (0-indexed) and day from a stored birthday, which is either
+// a full ISO date ("YYYY-MM-DD") or a year-less date ("--MM-DD").
+export function parseBirthdayMonthDay(birthdayISO: string): { month: number; day: number } | undefined {
+  if (!birthdayISO) return undefined;
+
+  let month: number;
+  let day: number;
+
+  if (birthdayISO.startsWith('--')) {
+    month = parseInt(birthdayISO.substring(2, 4), 10) - 1;
+    day = parseInt(birthdayISO.substring(5, 7), 10);
+  } else {
+    const parts = birthdayISO.split('-');
+    if (parts.length !== 3) return undefined;
+    month = parseInt(parts[1], 10) - 1;
+    day = parseInt(parts[2], 10);
+  }
+
+  if (isNaN(month) || isNaN(day)) return undefined;
+  return { month, day };
+}
+
+// Next occurrence (this year or next) of the given birthday, at 09:00 local time.
+export function computeNextBirthdayOccurrence(birthdayISO: string): Date | undefined {
+  const monthDay = parseBirthdayMonthDay(birthdayISO);
+  if (!monthDay) return undefined;
+
+  const today = new Date();
+  const nextBirthday = new Date(today.getFullYear(), monthDay.month, monthDay.day);
+
+  if (nextBirthday < today) {
+    nextBirthday.setFullYear(today.getFullYear() + 1);
+  }
+
+  nextBirthday.setHours(9, 0, 0, 0);
+  return nextBirthday;
+}
+
+export function buildBirthdayReminderPayload(
+  contactId: number,
+  birthdayISO: string,
+  message: string
+): ReminderFormData | undefined {
+  const nextOccurrence = computeNextBirthdayOccurrence(birthdayISO);
+  if (!nextOccurrence) return undefined;
+
+  return {
+    message,
+    by_mail: true,
+    remind_at: nextOccurrence.toISOString(),
+    recurrence: 'yearly',
+    reoccur_from_completion: false,
+    contact_id: contactId
+  };
+}
+
+// Heuristic match: a birthday reminder is a yearly, calendar-pinned reminder
+// whose month/day matches the contact's birthday. There is no dedicated
+// "type" field on Reminder, so this convention is relied on across the app
+// (see backend/services/monica_import_service.go's isBirthdayReminder).
+export function findBirthdayReminder(reminders: Reminder[], birthdayISO: string): Reminder | undefined {
+  const monthDay = parseBirthdayMonthDay(birthdayISO);
+  if (!monthDay) return undefined;
+
+  const matches = reminders.filter((reminder) => {
+    if (reminder.recurrence !== 'yearly' || reminder.reoccur_from_completion) return false;
+    const remindAt = new Date(reminder.remind_at);
+    return remindAt.getMonth() === monthDay.month && remindAt.getDate() === monthDay.day;
+  });
+
+  if (matches.length === 0) return undefined;
+
+  return matches.reduce((earliest, current) =>
+    new Date(current.remind_at) < new Date(earliest.remind_at) ? current : earliest
+  );
+}


### PR DESCRIPTION
Add a switch next to the birthday field on the contact detail page to create or remove the birthday reminder after contact creation. The reminder is kept in sync when the birthday date is edited or cleared.

Extract the birthday-reminder date/payload logic shared with the contact creation dialog into utils/birthdayReminder.ts.
Ref #176 